### PR TITLE
modified `unfinishedTodosRegex` such that it preseve indentation when discovering tasks

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ export default class RolloverTodosPlugin extends Plugin {
 
 	async getAllUnfinishedTodos(file) {
 		const contents = await this.app.vault.read(file);
-		const unfinishedTodosRegex = /- \[ \].*/g
+		const unfinishedTodosRegex = /\t*- \[ \].*/g
 		const unfinishedTodos = Array.from(contents.matchAll(unfinishedTodosRegex)).map(([todo]) => todo)
 		return unfinishedTodos;
 	}


### PR DESCRIPTION
Per request, this PR modifies the regex used for finding tasks to include indentation thus preserving it when rolling notes over from the previous daily note.