### PR TITLE
fix/broken-plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,7 @@ package-lock.json
 main.js
 *.js.map
 
+# obsidian dev files
+data.json
+
 .DS_Store

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 import { Notice, Plugin, Setting, PluginSettingTab } from 'obsidian';
 
+const MAX_TIME_SINCE_CREATION = 5000; // 5 seconds
+
 export default class RolloverTodosPlugin extends Plugin {
 	checkDailyNotesEnabled() {
 		return this.app.vault.config.pluginEnabledStatus['daily-notes'];
@@ -51,7 +53,7 @@ export default class RolloverTodosPlugin extends Plugin {
 			if (today.toISOString().slice(0, 10) !== file.basename) return;
 
 			// was just created
-			if (today.getTime() - file.stat.ctime > 1) return;
+			if (today.getTime() - file.stat.ctime > MAX_TIME_SINCE_CREATION) return;
 
 			const lastDailyNote = this.getLastDailyNote();
 			if (lastDailyNote == null) return;
@@ -61,10 +63,10 @@ export default class RolloverTodosPlugin extends Plugin {
 			let dailyNoteContent = await this.app.vault.read(file)
 
 			if (this.settings.templateHeading !== 'none') {
-				const heading = this.settings.templateHeading + '\n'
-				dailyNoteContent = dailyNoteContent.replace(heading, heading + unfinishedTodos.join('\n') + '\n')
+				const heading = this.settings.templateHeading;
+				dailyNoteContent = dailyNoteContent.replace(heading, heading + '\n' + unfinishedTodos.join('\n') + '\n')
 			} else {
-				dailyNoteContent += unfinishedTodos.join('\n')
+				dailyNoteContent += '\n' + unfinishedTodos.join('\n')
 			}
 
 			await this.app.vault.modify(file, dailyNoteContent);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "obsidian-sample-plugin",
+  "name": "obsidian-rollover-daily-todos",
   "version": "0.9.7",
-  "description": "This is a sample plugin for Obsidian (https://obsidian.md)",
+  "description": "This plugin rolls over incomplete TODOs to the next daily note for Obsidian (https://obsidian.md)",
   "main": "main.js",
   "scripts": {
     "dev": "rollup --config rollup.config.js -w",


### PR DESCRIPTION
- Created since duration was just 1ms. Obsisdian provides no guarantee
the plugin event will fire that quickly. In testing, 7ms was the
average. I've extended this to 5 seconds, as I can't see any reason to
need it to be more recent than that.

- The plugin relied upon the header having an empty line after it in the
template. Where this was not the case, the TODOs would not be injected.
I've removed that requirement.

- Where no header is selected in settings, we should add a new line
before injecting the TODOs, instead of appending to whatever is
currently on the bottom line.

## Should Resolve
https://github.com/shichongrui/obsidian-rollover-daily-todos/issues/3
