### PR TITLE
Check plugin enabled status from internal plugins list, not config.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const MAX_TIME_SINCE_CREATION = 5000; // 5 seconds
 
 export default class RolloverTodosPlugin extends Plugin {
 	checkDailyNotesEnabled() {
-		return this.app.vault.config.pluginEnabledStatus['daily-notes'];
+        const plugin = this.app.internalPlugins.plugins['daily-notes'];
+        return plugin && plugin.enabled;
 	}
 
 	getDailyNotesDirectory() {


### PR DESCRIPTION
This broke after some recent update. It looks like the config object doesn't contain any info about which plugins are enabled.

Instead, we can just check the internal plugins object.

This works: 
![CleanShot 2021-08-20 at 12 16 40](https://user-images.githubusercontent.com/10165957/130289011-05fe858a-9214-4162-a95f-7f1fc56d8058.gif)
