### PR TITLE
Support core Daily Notes plugin date format

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "@rollup/plugin-node-resolve": "^9.0.0",
     "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
     "rollup": "^2.32.1"
+  },
+  "dependencies": {
+    "moment": "^2.29.1"
   }
 }


### PR DESCRIPTION
The core daily notes plugin allows for a custom date format to be defined. This PR aims to add support for that feature.

I've used momentjs for date handling as that was already being used inside obsidian, and that's what's mentioned in the docs for the date format of the daily notes plugin.

Fixes #24 