### PR TITLE
Compare full path instead of basename

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -118,7 +118,8 @@ export default class RolloverTodosPlugin extends Plugin {
     // is today's daily note
     const today = new Date();
     const todayFormatted = window.moment(today).format(format);
-    if (todayFormatted !== file.basename) return;
+    const filePathConstructed = `${folder}${todayFormatted}.${file.extension}`;
+    if (filePathConstructed !== file.path) return;
 
     // was just created
     if ((today.getTime() - file.stat.ctime > MAX_TIME_SINCE_CREATION) && !ignoreCreationTime) return;


### PR DESCRIPTION
This PR allows using date formates that use `/` to create subfolders in Obsidian for daily notes. See issue: https://github.com/shichongrui/obsidian-rollover-daily-todos/issues/56 

Testing it on my personal vault had no side effects other than the expected output of the plugin. 